### PR TITLE
ci(github): remove PR body empty check step from workflow

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -19,15 +19,3 @@ jobs:
           requireScope: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  pr-body:
-    name: PR body empty check
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - run: |
-          if [[ -z "${PR_BODY// }" ]]; then
-            echo "PR body is empty"
-            exit 1
-          fi
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}


### PR DESCRIPTION
Remove PR body empty check step, because coderabbit always write PR body.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - プルリクエスト本文が空かどうかをチェックする自動テストを削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->