### PR TITLE
ci(action): Add CI permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   all-status-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Specify only needed permissions for security.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
  - GitHub ActionsのCIワークフローにおいて、リポジトリの内容の読み取りおよびチェックとプルリクエストへの書き込み権限を明示的に設定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->