### PR TITLE
fix(logger): Set StreamHandler level to match logger's level

### DIFF
--- a/akari/logger.py
+++ b/akari/logger.py
@@ -10,6 +10,6 @@ def getLogger(name: str, level: int = logging.DEBUG) -> AkariLogger:
     logger.addHandler(logging.NullHandler())
 
     handler = logging.StreamHandler(sys.stdout)
-    handler.setLevel(logging.DEBUG)
+    handler.setLevel(level)
     logger.addHandler(handler)
     return logger


### PR DESCRIPTION
Don't hard code the logging level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - ログハンドラーの出力レベルが、指定したログレベルに正しく従うようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->