### PR TITLE
refactor(akari): make the unpackaged private

### DIFF
--- a/akari/__init__.py
+++ b/akari/__init__.py
@@ -1,7 +1,16 @@
-from .data import AkariData, AkariDataSet, AkariDataSetType, AkariDataStreamType
-from .logger import AkariLogger, getLogger
-from .module import AkariModule, AkariModuleParams, AkariModuleType
-from .router import MainRouter
+from .data import (
+    _AkariData as AkariData,
+    _AkariDataSet as AkariDataSet,
+    _AkariDataSetType as AkariDataSetType,
+    _AkariDataStreamType as AkariDataStreamType,
+)
+from .logger import _AkariLogger as AkariLogger, _getLogger as getLogger
+from .module import (
+    _AkariModule as AkariModule,
+    _AkariModuleParams as AkariModuleParams,
+    _AkariModuleType as AkariModuleType,
+)
+from .router import _MainRouter as AkariRouter
 
 __all__ = [
     "AkariData",
@@ -11,7 +20,7 @@ __all__ = [
     "AkariModule",
     "AkariModuleParams",
     "AkariModuleType",
-    "MainRouter",
+    "AkariRouter",
     "AkariLogger",
     "getLogger",
 ]

--- a/akari/__init__.py
+++ b/akari/__init__.py
@@ -1,15 +1,12 @@
-from .data import (
-    _AkariData as AkariData,
-    _AkariDataSet as AkariDataSet,
-    _AkariDataSetType as AkariDataSetType,
-    _AkariDataStreamType as AkariDataStreamType,
-)
-from .logger import _AkariLogger as AkariLogger, _getLogger as getLogger
-from .module import (
-    _AkariModule as AkariModule,
-    _AkariModuleParams as AkariModuleParams,
-    _AkariModuleType as AkariModuleType,
-)
+from .data import _AkariData as AkariData
+from .data import _AkariDataSet as AkariDataSet
+from .data import _AkariDataSetType as AkariDataSetType
+from .data import _AkariDataStreamType as AkariDataStreamType
+from .logger import _AkariLogger as AkariLogger
+from .logger import _getLogger as getLogger
+from .module import _AkariModule as AkariModule
+from .module import _AkariModuleParams as AkariModuleParams
+from .module import _AkariModuleType as AkariModuleType
 from .router import _MainRouter as AkariRouter
 
 __all__ = [

--- a/akari/data.py
+++ b/akari/data.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Generic, TypeVar
 T = TypeVar("T")
 
 
-class AkariDataStreamType(Generic[T]):
+class _AkariDataStreamType(Generic[T]):
     def __init__(self, delta: list[T]) -> None:
         self._delta = delta
 
@@ -24,9 +24,9 @@ class AkariDataStreamType(Generic[T]):
         return f"AkariDataStreamType(delta={self._delta})"
 
 
-class AkariDataSetType(Generic[T]):
+class _AkariDataSetType(Generic[T]):
     def __init__(
-        self, main: T, stream: AkariDataStreamType[T] | None = None, others: Dict[str, T] | None = None
+        self, main: T, stream: _AkariDataStreamType[T] | None = None, others: Dict[str, T] | None = None
     ) -> None:
         self.main = main
         self.stream = stream
@@ -36,31 +36,31 @@ class AkariDataSetType(Generic[T]):
         return f"AkariDataSetType(main={self.main}, stream={self.stream}, others={self.others})"
 
 
-class AkariDataSet:
+class _AkariDataSet:
     def __init__(self) -> None:
-        self.text: AkariDataSetType[str] | None = None
-        self.audio: AkariDataSetType[bytes] | None = None
+        self.text: _AkariDataSetType[str] | None = None
+        self.audio: _AkariDataSetType[bytes] | None = None
         self.allData: Any | None = None
 
 
-class AkariData:
+class _AkariData:
     def __init__(self) -> None:
-        self.datasets: list[AkariDataSet] = []
+        self.datasets: list[_AkariDataSet] = []
 
-    def add(self, dataset: AkariDataSet) -> None:
+    def add(self, dataset: _AkariDataSet) -> None:
         self.datasets.append(dataset)
 
-    def get(self, index: int) -> AkariDataSet:
+    def get(self, index: int) -> _AkariDataSet:
         if index < 0 or index >= len(self.datasets):
             raise IndexError("Index out of range")
         return self.datasets[index]
 
-    def last(self) -> AkariDataSet:
+    def last(self) -> _AkariDataSet:
         if not self.datasets:
             raise IndexError("No datasets available")
         return self.datasets[-1]
 
-    def __getitem__(self, index: int) -> AkariDataSet:
+    def __getitem__(self, index: int) -> _AkariDataSet:
         return self.get(index)
 
     def __len__(self) -> int:

--- a/akari/logger.py
+++ b/akari/logger.py
@@ -1,10 +1,10 @@
 import logging
 import sys
 
-AkariLogger = logging.Logger
+_AkariLogger = logging.Logger
 
 
-def getLogger(name: str, level: int = logging.DEBUG) -> AkariLogger:
+def _getLogger(name: str, level: int = logging.DEBUG) -> _AkariLogger:
     logger = logging.getLogger(name)
     logger.setLevel(level)
     logger.addHandler(logging.NullHandler())

--- a/akari/module.py
+++ b/akari/module.py
@@ -9,22 +9,22 @@ import akari.logger as logger
 if TYPE_CHECKING:
     import akari.router as router
 
-AkariModuleParams = Any
-AkariModuleType = type["AkariModule"]
+_AkariModuleParams = Any
+_AkariModuleType = type["AkariModule"]
 
 
-class AkariModule(ABC):
-    def __init__(self, router: router.MainRouter, logger: logger.AkariLogger) -> None:
+class _AkariModule(ABC):
+    def __init__(self, router: router._MainRouter, logger: logger._AkariLogger) -> None:
         self._router = router
         self._logger = logger
 
     @abstractmethod
     def call(
-        self, data: data.AkariData, params: AkariModuleParams, callback: AkariModuleType | None = None
-    ) -> data.AkariDataSet:
+        self, data: data._AkariData, params: _AkariModuleParams, callback: _AkariModuleType | None = None
+    ) -> data._AkariDataSet:
         pass
 
     def stream_call(
-        self, data: data.AkariData, params: AkariModuleParams, callback: AkariModuleType | None = None
-    ) -> data.AkariDataSet:
+        self, data: data._AkariData, params: _AkariModuleParams, callback: _AkariModuleType | None = None
+    ) -> data._AkariDataSet:
         raise NotImplementedError("stream_call is not implemented in this module.")

--- a/akari/module.py
+++ b/akari/module.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     import akari.router as router
 
 _AkariModuleParams = Any
-_AkariModuleType = type["AkariModule"]
+_AkariModuleType = type["_AkariModule"]
 
 
 class _AkariModule(ABC):

--- a/akari/router.py
+++ b/akari/router.py
@@ -6,22 +6,22 @@ import akari.logger as logger
 import akari.module as module
 
 
-class MainRouter:
-    def __init__(self, logger: logger.AkariLogger) -> None:
-        self._modules: Dict[module.AkariModuleType, module.AkariModule] | None = None
+class _MainRouter:
+    def __init__(self, logger: logger._AkariLogger) -> None:
+        self._modules: Dict[module._AkariModuleType, module._AkariModule] | None = None
         self._logger = logger
 
-    def setModules(self, modules: Dict[module.AkariModuleType, module.AkariModule]) -> None:
+    def setModules(self, modules: Dict[module._AkariModuleType, module._AkariModule]) -> None:
         self._modules = modules
 
     def callModule(
         self,
-        moduleType: module.AkariModuleType,
-        data: data.AkariData,
-        params: module.AkariModuleParams,
+        moduleType: module._AkariModuleType,
+        data: data._AkariData,
+        params: module._AkariModuleParams,
         streaming: bool,
-        callback: module.AkariModuleType | None = None,
-    ) -> data.AkariData:
+        callback: module._AkariModuleType | None = None,
+    ) -> data._AkariData:
         """
         Args:
             streaming (bool): 呼び出し元がストリームしているかどうかのフラグ(=呼び出し先がストリームするかどうかの制御)

--- a/main.py
+++ b/main.py
@@ -53,7 +53,7 @@ vertexai.init(
 )
 
 
-akariRouter = akari.MainRouter(logger=akariLogger)
+akariRouter = akari.AkariRouter(logger=akariLogger)
 akariRouter.setModules(
     {
         modules.RootModule: modules.RootModule(akariRouter, akariLogger),

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,4 +1,4 @@
-from .print import PrintModule
-from .root import RootModule
+from .print import _PrintModule as PrintModule
+from .root import _RootModule as RootModule
 
 __all__ = ["RootModule", "PrintModule"]

--- a/modules/audio/__init__.py
+++ b/modules/audio/__init__.py
@@ -1,4 +1,6 @@
-from .mic import _MicModule as MicModule, _MicModuleParams as MicModuleParams
-from .speaker import _SpeakerModule as SpeakerModule, _SpeakerModuleParams as SpeakerModuleParams
+from .mic import _MicModule as MicModule
+from .mic import _MicModuleParams as MicModuleParams
+from .speaker import _SpeakerModule as SpeakerModule
+from .speaker import _SpeakerModuleParams as SpeakerModuleParams
 
 __all__ = ["SpeakerModule", "SpeakerModuleParams", "MicModule", "MicModuleParams"]

--- a/modules/audio/__init__.py
+++ b/modules/audio/__init__.py
@@ -1,4 +1,4 @@
-from .mic import MicModule, MicModuleParams
-from .speaker import SpeakerModule, SpeakerModuleParams
+from .mic import _MicModule as MicModule, _MicModuleParams as MicModuleParams
+from .speaker import _SpeakerModule as SpeakerModule, _SpeakerModuleParams as SpeakerModuleParams
 
 __all__ = ["SpeakerModule", "SpeakerModuleParams", "MicModule", "MicModuleParams"]

--- a/modules/audio/mic.py
+++ b/modules/audio/mic.py
@@ -18,7 +18,7 @@ from akari import (
 
 
 @dataclasses.dataclass
-class MicModuleParams:
+class _MicModuleParams:
     format: int = pyaudio.paInt16
     rate: int = 24000
     channels: int = 1
@@ -29,11 +29,11 @@ class MicModuleParams:
     callbackParams: Any | None = None
 
 
-class MicModule(AkariModule):
+class _MicModule(AkariModule):
     def __init__(self, router: MainRouter, logger: AkariLogger) -> None:
         super().__init__(router, logger)
 
-    def call(self, data: AkariData, params: MicModuleParams, callback: AkariModuleType | None = None) -> AkariDataSet:
+    def call(self, data: AkariData, params: _MicModuleParams, callback: AkariModuleType | None = None) -> AkariDataSet:
         dataset = AkariDataSet()
 
         audio = pyaudio.PyAudio()

--- a/modules/audio/mic.py
+++ b/modules/audio/mic.py
@@ -13,7 +13,7 @@ from akari import (
     AkariLogger,
     AkariModule,
     AkariModuleType,
-    MainRouter,
+    AkariRouter,
 )
 
 
@@ -30,7 +30,7 @@ class _MicModuleParams:
 
 
 class _MicModule(AkariModule):
-    def __init__(self, router: MainRouter, logger: AkariLogger) -> None:
+    def __init__(self, router: AkariRouter, logger: AkariLogger) -> None:
         super().__init__(router, logger)
 
     def call(self, data: AkariData, params: _MicModuleParams, callback: AkariModuleType | None = None) -> AkariDataSet:

--- a/modules/audio/speaker.py
+++ b/modules/audio/speaker.py
@@ -10,7 +10,7 @@ from akari import (
     AkariLogger,
     AkariModule,
     AkariModuleType,
-    MainRouter,
+    AkariRouter,
 )
 
 
@@ -24,7 +24,7 @@ class _SpeakerModuleParams:
 
 
 class _SpeakerModule(AkariModule):
-    def __init__(self, router: MainRouter, logger: AkariLogger) -> None:
+    def __init__(self, router: AkariRouter, logger: AkariLogger) -> None:
         super().__init__(router, logger)
 
     def call(

--- a/modules/audio/speaker.py
+++ b/modules/audio/speaker.py
@@ -15,7 +15,7 @@ from akari import (
 
 
 @dataclasses.dataclass
-class SpeakerModuleParams:
+class _SpeakerModuleParams:
     format: int = pyaudio.paInt16
     rate: int = 24000
     channels: int = 1
@@ -23,12 +23,12 @@ class SpeakerModuleParams:
     output_device_index: int | None = None
 
 
-class SpeakerModule(AkariModule):
+class _SpeakerModule(AkariModule):
     def __init__(self, router: MainRouter, logger: AkariLogger) -> None:
         super().__init__(router, logger)
 
     def call(
-        self, data: AkariData, params: SpeakerModuleParams, callback: AkariModuleType | None = None
+        self, data: AkariData, params: _SpeakerModuleParams, callback: AkariModuleType | None = None
     ) -> AkariDataSet:
         audio = data.last().audio
         if audio is None:
@@ -62,7 +62,7 @@ class SpeakerModule(AkariModule):
         return dataset
 
     def stream_call(
-        self, data: AkariData, params: SpeakerModuleParams, callback: AkariModuleType | None = None
+        self, data: AkariData, params: _SpeakerModuleParams, callback: AkariModuleType | None = None
     ) -> AkariDataSet:
         audio = data.last().audio
         if audio is None:

--- a/modules/azure_openai/__init__.py
+++ b/modules/azure_openai/__init__.py
@@ -1,5 +1,8 @@
-from .llm import _LLMModule as LLMModule, _LLMModuleParams as LLMModuleParams
-from .stt import _STTModule as STTModule, _STTModuleParams as STTModuleParams
-from .tts import _TTSModule as TTSModule, _TTSModuleParams as TTSModuleParams
+from .llm import _LLMModule as LLMModule
+from .llm import _LLMModuleParams as LLMModuleParams
+from .stt import _STTModule as STTModule
+from .stt import _STTModuleParams as STTModuleParams
+from .tts import _TTSModule as TTSModule
+from .tts import _TTSModuleParams as TTSModuleParams
 
 __all__ = ["LLMModule", "LLMModuleParams", "STTModule", "STTModuleParams", "TTSModule", "TTSModuleParams"]

--- a/modules/azure_openai/__init__.py
+++ b/modules/azure_openai/__init__.py
@@ -1,5 +1,5 @@
-from .llm import LLMModule, LLMModuleParams
-from .stt import STTModule, STTModuleParams
-from .tts import TTSModule, TTSModuleParams
+from .llm import _LLMModule as LLMModule, _LLMModuleParams as LLMModuleParams
+from .stt import _STTModule as STTModule, _STTModuleParams as STTModuleParams
+from .tts import _TTSModule as TTSModule, _TTSModuleParams as TTSModuleParams
 
 __all__ = ["LLMModule", "LLMModuleParams", "STTModule", "STTModuleParams", "TTSModule", "TTSModuleParams"]

--- a/modules/azure_openai/llm.py
+++ b/modules/azure_openai/llm.py
@@ -17,7 +17,7 @@ from akari import (
     AkariLogger,
     AkariModule,
     AkariModuleType,
-    MainRouter,
+    AkariRouter,
 )
 
 
@@ -34,7 +34,7 @@ class _LLMModuleParams:
 
 
 class _LLMModule(AkariModule):
-    def __init__(self, router: MainRouter, logger: AkariLogger, client: AzureOpenAI) -> None:
+    def __init__(self, router: AkariRouter, logger: AkariLogger, client: AzureOpenAI) -> None:
         super().__init__(router, logger)
         self.client = client
 

--- a/modules/azure_openai/llm.py
+++ b/modules/azure_openai/llm.py
@@ -22,7 +22,7 @@ from akari import (
 
 
 @dataclasses.dataclass
-class LLMModuleParams:
+class _LLMModuleParams:
     model: str
     messages: Iterable[ChatCompletionMessageParam]
     temperature: float = 1.0
@@ -33,12 +33,12 @@ class LLMModuleParams:
     stream: bool = False
 
 
-class LLMModule(AkariModule):
+class _LLMModule(AkariModule):
     def __init__(self, router: MainRouter, logger: AkariLogger, client: AzureOpenAI) -> None:
         super().__init__(router, logger)
         self.client = client
 
-    def call(self, data: AkariData, params: LLMModuleParams, callback: AkariModuleType | None = None) -> AkariDataSet:
+    def call(self, data: AkariData, params: _LLMModuleParams, callback: AkariModuleType | None = None) -> AkariDataSet:
         self._logger.debug("LLMModule called")
         self._logger.debug("Data: %s", data)
         self._logger.debug("Params: %s", params)

--- a/modules/azure_openai/stt.py
+++ b/modules/azure_openai/stt.py
@@ -10,7 +10,7 @@ from akari import (
     AkariLogger,
     AkariModule,
     AkariModuleType,
-    MainRouter,
+    AkariRouter,
 )
 
 
@@ -23,7 +23,7 @@ class _STTModuleParams:
 
 
 class _STTModule(AkariModule):
-    def __init__(self, router: MainRouter, logger: AkariLogger, client: AzureOpenAI) -> None:
+    def __init__(self, router: AkariRouter, logger: AkariLogger, client: AzureOpenAI) -> None:
         super().__init__(router, logger)
         self.client = client
 

--- a/modules/azure_openai/stt.py
+++ b/modules/azure_openai/stt.py
@@ -15,19 +15,19 @@ from akari import (
 
 
 @dataclasses.dataclass
-class STTModuleParams:
+class _STTModuleParams:
     model: str
     language: str | None
     prompt: str | None
     temperature: float
 
 
-class STTModule(AkariModule):
+class _STTModule(AkariModule):
     def __init__(self, router: MainRouter, logger: AkariLogger, client: AzureOpenAI) -> None:
         super().__init__(router, logger)
         self.client = client
 
-    def call(self, data: AkariData, params: STTModuleParams, callback: AkariModuleType | None = None) -> AkariDataSet:
+    def call(self, data: AkariData, params: _STTModuleParams, callback: AkariModuleType | None = None) -> AkariDataSet:
         self._logger.debug("STTModule called")
         self._logger.debug("Data: %s", data)
         self._logger.debug("Params: %s", params)

--- a/modules/azure_openai/tts.py
+++ b/modules/azure_openai/tts.py
@@ -10,7 +10,7 @@ from akari import (
     AkariLogger,
     AkariModule,
     AkariModuleType,
-    MainRouter,
+    AkariRouter,
 )
 
 
@@ -25,7 +25,7 @@ class _TTSModuleParams:
 
 
 class _TTSModule(AkariModule):
-    def __init__(self, router: MainRouter, logger: AkariLogger, client: AzureOpenAI) -> None:
+    def __init__(self, router: AkariRouter, logger: AkariLogger, client: AzureOpenAI) -> None:
         super().__init__(router, logger)
         self.client = client
 

--- a/modules/azure_openai/tts.py
+++ b/modules/azure_openai/tts.py
@@ -15,7 +15,7 @@ from akari import (
 
 
 @dataclasses.dataclass
-class TTSModuleParams:
+class _TTSModuleParams:
     model: str
     input: str
     voice: str
@@ -24,12 +24,12 @@ class TTSModuleParams:
     speed: float = 1.0
 
 
-class TTSModule(AkariModule):
+class _TTSModule(AkariModule):
     def __init__(self, router: MainRouter, logger: AkariLogger, client: AzureOpenAI) -> None:
         super().__init__(router, logger)
         self.client = client
 
-    def call(self, data: AkariData, params: TTSModuleParams, callback: AkariModuleType | None = None) -> AkariDataSet:
+    def call(self, data: AkariData, params: _TTSModuleParams, callback: AkariModuleType | None = None) -> AkariDataSet:
         self._logger.debug("TTSModule called")
         self._logger.debug("Data: %s", data)
         self._logger.debug("Params: %s", params)

--- a/modules/gemini/__init__.py
+++ b/modules/gemini/__init__.py
@@ -1,3 +1,3 @@
-from .llm import LLMModule, LLMModuleParams
+from .llm import _LLMModule as LLMModule, _LLMModuleParams as LLMModuleParams
 
 __all__ = ["LLMModule", "LLMModuleParams"]

--- a/modules/gemini/__init__.py
+++ b/modules/gemini/__init__.py
@@ -1,3 +1,4 @@
-from .llm import _LLMModule as LLMModule, _LLMModuleParams as LLMModuleParams
+from .llm import _LLMModule as LLMModule
+from .llm import _LLMModuleParams as LLMModuleParams
 
 __all__ = ["LLMModule", "LLMModuleParams"]

--- a/modules/gemini/llm.py
+++ b/modules/gemini/llm.py
@@ -10,7 +10,7 @@ from akari import (
     AkariLogger,
     AkariModule,
     AkariModuleType,
-    MainRouter,
+    AkariRouter,
 )
 
 _models: dict[str, GenerativeModel] = {}
@@ -23,7 +23,7 @@ class _LLMModuleParams:
 
 
 class _LLMModule(AkariModule):
-    def __init__(self, router: MainRouter, logger: AkariLogger) -> None:
+    def __init__(self, router: AkariRouter, logger: AkariLogger) -> None:
         super().__init__(router, logger)
 
     def call(self, data: AkariData, params: _LLMModuleParams, callback: AkariModuleType | None = None) -> AkariDataSet:

--- a/modules/gemini/llm.py
+++ b/modules/gemini/llm.py
@@ -17,16 +17,16 @@ _models: dict[str, GenerativeModel] = {}
 
 
 @dataclasses.dataclass
-class LLMModuleParams:
+class _LLMModuleParams:
     model: str
     messages: Iterable[Content]
 
 
-class LLMModule(AkariModule):
+class _LLMModule(AkariModule):
     def __init__(self, router: MainRouter, logger: AkariLogger) -> None:
         super().__init__(router, logger)
 
-    def call(self, data: AkariData, params: LLMModuleParams, callback: AkariModuleType | None = None) -> AkariDataSet:
+    def call(self, data: AkariData, params: _LLMModuleParams, callback: AkariModuleType | None = None) -> AkariDataSet:
         self._logger.debug("LLMModule called")
         self._logger.debug("Data: %s", data)
         self._logger.debug("Params: %s", params)

--- a/modules/print.py
+++ b/modules/print.py
@@ -12,7 +12,7 @@ from akari import (
 )
 
 
-class PrintModule(AkariModule):
+class _PrintModule(AkariModule):
     def __init__(self, router: MainRouter, logger: AkariLogger) -> None:
         super().__init__(router, logger)
 

--- a/modules/print.py
+++ b/modules/print.py
@@ -8,12 +8,12 @@ from akari import (
     AkariLogger,
     AkariModule,
     AkariModuleType,
-    MainRouter,
+    AkariRouter,
 )
 
 
 class _PrintModule(AkariModule):
-    def __init__(self, router: MainRouter, logger: AkariLogger) -> None:
+    def __init__(self, router: AkariRouter, logger: AkariLogger) -> None:
         super().__init__(router, logger)
 
     def call(self, data: AkariData, params: Any, callback: AkariModuleType | None = None) -> AkariDataSet:

--- a/modules/root.py
+++ b/modules/root.py
@@ -5,12 +5,12 @@ from akari import (
     AkariModule,
     AkariModuleParams,
     AkariModuleType,
-    MainRouter,
+    AkariRouter,
 )
 
 
 class _RootModule(AkariModule):
-    def __init__(self, router: MainRouter, logger: AkariLogger) -> None:
+    def __init__(self, router: AkariRouter, logger: AkariLogger) -> None:
         super().__init__(router, logger)
 
     def call(self, data: AkariData, params: AkariModuleParams, callback: AkariModuleType | None = None) -> AkariDataSet:

--- a/modules/root.py
+++ b/modules/root.py
@@ -9,7 +9,7 @@ from akari import (
 )
 
 
-class RootModule(AkariModule):
+class _RootModule(AkariModule):
     def __init__(self, router: MainRouter, logger: AkariLogger) -> None:
         super().__init__(router, logger)
 

--- a/sample/__init__.py
+++ b/sample/__init__.py
@@ -1,3 +1,3 @@
-from .module import SampleModule
+from .module import _SampleModule as SampleModule
 
 __all__ = ["SampleModule"]

--- a/sample/module.py
+++ b/sample/module.py
@@ -9,7 +9,7 @@ from akari import (
 )
 
 
-class SampleModule(AkariModule):
+class _SampleModule(AkariModule):
     def __init__(self, router: MainRouter, logger: AkariLogger) -> None:
         super().__init__(router, logger)
 

--- a/sample/module.py
+++ b/sample/module.py
@@ -5,12 +5,12 @@ from akari import (
     AkariModule,
     AkariModuleParams,
     AkariModuleType,
-    MainRouter,
+    AkariRouter,
 )
 
 
 class _SampleModule(AkariModule):
-    def __init__(self, router: MainRouter, logger: AkariLogger) -> None:
+    def __init__(self, router: AkariRouter, logger: AkariLogger) -> None:
         super().__init__(router, logger)
 
     def call(self, data: AkariData, params: AkariModuleParams, callback: AkariModuleType | None = None) -> AkariDataSet:

--- a/tests/test_sample_module.py
+++ b/tests/test_sample_module.py
@@ -1,12 +1,12 @@
 import pytest
 
-from akari import AkariData, AkariDataSet, AkariLogger, MainRouter
+from akari import AkariData, AkariDataSet, AkariLogger, AkariRouter
 from sample.module import _SampleModule
 
 
 @pytest.fixture
-def main_router(logger: AkariLogger) -> MainRouter:
-    return MainRouter(logger=logger)
+def main_router(logger: AkariLogger) -> AkariRouter:
+    return AkariRouter(logger=logger)
 
 
 @pytest.fixture
@@ -15,7 +15,7 @@ def logger() -> AkariLogger:
 
 
 @pytest.fixture
-def sample_module(main_router: MainRouter, logger: AkariLogger) -> _SampleModule:
+def sample_module(main_router: AkariRouter, logger: AkariLogger) -> _SampleModule:
     return _SampleModule(main_router, logger)
 
 

--- a/tests/test_sample_module.py
+++ b/tests/test_sample_module.py
@@ -1,7 +1,7 @@
 import pytest
 
 from akari import AkariData, AkariDataSet, AkariLogger, MainRouter
-from sample.module import SampleModule
+from sample.module import _SampleModule
 
 
 @pytest.fixture
@@ -15,11 +15,11 @@ def logger() -> AkariLogger:
 
 
 @pytest.fixture
-def sample_module(main_router: MainRouter, logger: AkariLogger) -> SampleModule:
-    return SampleModule(main_router, logger)
+def sample_module(main_router: MainRouter, logger: AkariLogger) -> _SampleModule:
+    return _SampleModule(main_router, logger)
 
 
-def test_sample_module_call(sample_module: SampleModule) -> None:
+def test_sample_module_call(sample_module: _SampleModule) -> None:
     data = AkariData()
 
     result = sample_module.call(data, None)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **リファクタリング**
  - 内部クラスや型名をアンダースコア付きに変更し、公開APIとしては元の名前で再エクスポートされるようになりました。
  - ルーターのクラス名を統一し、型アノテーションも新しい名前に更新されました。
  - モジュール間のインポートやエクスポート方法が整理され、外部からの利用方法は変わりません。

- **テスト**
  - テストコードも新しいクラス名や型名に合わせて修正されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->