### PR TITLE
docs(README): update README with Python command usage guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ What is Akari? The answer, as it must, will eventually be revealed.
 
 You must always follow the specifications listed in `docs/`.
 
+When you type Python-based commands, you need to prefix them with `poetry run`, as shown in [#Tasks](#tasks).
+
+Example:
+
+- to lint `poetry run flake8 .`
+- to format `poetry run black .`
+
 ## Development
 
 Setup the environment:


### PR DESCRIPTION
- Added instructions to prefix Python commands with `poetry run`.
- Included examples for linting and formatting commands to enhance developer clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - Pythonコマンドを実行する際に `poetry run` を付ける必要がある旨の注意書きをREADMEに追加しました。
  - `poetry run flake8 .` と `poetry run black .` の例を記載しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->